### PR TITLE
Fix code scanning alert no. 1: Uncontrolled command line

### DIFF
--- a/apps/fastapi_app.py
+++ b/apps/fastapi_app.py
@@ -36,15 +36,22 @@ async def upload_return_large_file(file: UploadFile = File(...)):
 
 @app.get("/cmdi")
 def cmdi(user_input: str):
-    cmd = "echo " + user_input + " this should be echoed"
-    print("Started app view")
-    for i in range(10):
-        print("will echo command")
-        os.system(cmd)
-        print("about to sleep")
-        sleep(3)
-        print("done sleeping")
-    print("Finished app view")
+    allowed_commands = {
+        "hello": "echo hello this should be echoed",
+        "world": "echo world this should be echoed"
+    }
+    if user_input in allowed_commands:
+        cmd = allowed_commands[user_input]
+        print("Started app view")
+        for i in range(10):
+            print("will echo command")
+            os.system(cmd)
+            print("about to sleep")
+            sleep(3)
+            print("done sleeping")
+        print("Finished app view")
+    else:
+        return {"error": "Invalid command"}
 
 
 @app.get("/async_will_block")


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Python_2/security/code-scanning/1](https://github.com/Brook-5686/Python_2/security/code-scanning/1)

To fix the problem, we need to ensure that the user input is sanitized or validated before being used in a command. The best way to fix this issue is to use a predefined allowlist of acceptable commands or inputs. This way, we can ensure that only safe commands are executed.

In this specific case, we can create a dictionary of allowed commands and their corresponding safe command strings. We will then look up the user input in this dictionary and use the corresponding safe command string. If the user input is not in the allowlist, we can return an error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
