### PR TITLE
Fix code scanning alert no. 5: Reflected server-side cross-site scripting

### DIFF
--- a/src/vulnpy/django/vulnerable_asgi.py
+++ b/src/vulnpy/django/vulnerable_asgi.py
@@ -1,6 +1,7 @@
 from django.http import HttpResponse
 import django
 import urllib.parse
+import html
 
 try:
     from django.conf.urls import url as compat_url
@@ -52,7 +53,7 @@ def get_trigger_view(name, trigger):
         template = get_template("{}.html".format(name))
 
         if name == "xss" and trigger == "raw":
-            template += "<p>XSS: " + user_input + "</p>"
+            template += "<p>XSS: " + html.escape(user_input) + "</p>"
 
         return HttpResponse(template)
 


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Python_2/security/code-scanning/5](https://github.com/Brook-5686/Python_2/security/code-scanning/5)

To fix the reflected cross-site scripting vulnerability, we need to ensure that any user input included in the HTML response is properly escaped. This can be achieved by using the `html.escape()` function from the standard library, which will convert special characters to their corresponding HTML-safe sequences.

The best way to fix the problem without changing existing functionality is to escape the `user_input` before appending it to the `template`. This ensures that any potentially malicious scripts are rendered harmless by converting special characters to their HTML-safe equivalents.

We need to modify the `get_trigger_view` function to escape the `user_input` before including it in the `template`. Specifically, we will import the `html` module and use the `html.escape()` function to sanitize the `user_input`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
