### PR TITLE
Fix code scanning alert no. 4: Reflected server-side cross-site scripting

### DIFF
--- a/src/vulnpy/fastapi/vulnerable.py
+++ b/src/vulnpy/fastapi/vulnerable.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 from fastapi.responses import HTMLResponse
-
+import html
 from vulnpy.common import get_template
 
 from vulnpy.trigger import TRIGGER_MAP, get_trigger
@@ -39,7 +39,7 @@ def get_trigger_view(name, trigger):
         template = get_template("{}.html".format(name))
 
         if name == "xss" and trigger == "raw":
-            template += "<p>XSS: " + user_input + "</p>"
+            template += "<p>XSS: " + html.escape(user_input) + "</p>"
 
         return HTMLResponse(template)
 


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Python_2/security/code-scanning/4](https://github.com/Brook-5686/Python_2/security/code-scanning/4)

To fix the problem, we need to ensure that any user input included in the HTML response is properly escaped to prevent XSS attacks. The `html.escape()` function from Python's standard library can be used to escape special characters in the user input, making it safe to include in the HTML response.

The best way to fix the problem without changing existing functionality is to import the `html` module and use the `html.escape()` function to sanitize `user_input` before concatenating it into the `template`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
